### PR TITLE
Make it work

### DIFF
--- a/Builder/Builder/Builder.csproj
+++ b/Builder/Builder/Builder.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.Build.Locator.1.0.13\build\Microsoft.Build.Locator.props" Condition="Exists('..\packages\Microsoft.Build.Locator.1.0.13\build\Microsoft.Build.Locator.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -11,6 +12,8 @@
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -32,6 +35,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Build.Locator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=9dff12846e04bfbd, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Build.Locator.1.0.13\lib\net46\Microsoft.Build.Locator.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CodeAnalysis, Version=2.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeAnalysis.Common.2.7.0\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
@@ -156,4 +162,12 @@ del "$(TargetDir)\Microsoft.Build.Tasks.Core.dll"
 del "$(TargetDir)\Microsoft.Build.Utilities.Core.dll"
 </PostBuildEvent>
   </PropertyGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Build.Locator.1.0.13\build\Microsoft.Build.Locator.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Build.Locator.1.0.13\build\Microsoft.Build.Locator.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Build.Locator.1.0.13\build\Microsoft.Build.Locator.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Build.Locator.1.0.13\build\Microsoft.Build.Locator.targets'))" />
+  </Target>
+  <Import Project="..\packages\Microsoft.Build.Locator.1.0.13\build\Microsoft.Build.Locator.targets" Condition="Exists('..\packages\Microsoft.Build.Locator.1.0.13\build\Microsoft.Build.Locator.targets')" />
 </Project>

--- a/Builder/Builder/Builder.csproj
+++ b/Builder/Builder/Builder.csproj
@@ -149,4 +149,11 @@
     <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.2.6.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>del "$(TargetDir)\Microsoft.Build.dll"
+del "$(TargetDir)\Microsoft.Build.Framework.dll"
+del "$(TargetDir)\Microsoft.Build.Tasks.Core.dll"
+del "$(TargetDir)\Microsoft.Build.Utilities.Core.dll"
+</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/Builder/Builder/Program.cs
+++ b/Builder/Builder/Program.cs
@@ -13,6 +13,7 @@ namespace Builder
     {
         static void Main(string[] args)
         {
+            // Locates all of the instances of Visual Studio 2017 on the machine with MSBuild.
             var instances = MSBuildLocator.QueryVisualStudioInstances().ToArray();
             if (!instances.Any())
             {
@@ -28,6 +29,8 @@ namespace Builder
                 Console.WriteLine();
             }
 
+            // We register the first instance that we found. This will cause MSBuildWorkspace to use the MSBuild installed in that instance.
+            // Note: This has to be registered *before* creating MSBuildWorkspace. Otherwise, the MEF composition used by MSBuildWorkspace will fail to compose.
             var registeredInstance = instances.First();
             MSBuildLocator.RegisterInstance(registeredInstance);
 

--- a/Builder/Builder/Program.cs
+++ b/Builder/Builder/Program.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis.MSBuild;
+﻿using Microsoft.Build.Locator;
+using Microsoft.CodeAnalysis.MSBuild;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -12,6 +13,27 @@ namespace Builder
     {
         static void Main(string[] args)
         {
+            var instances = MSBuildLocator.QueryVisualStudioInstances().ToArray();
+            if (!instances.Any())
+            {
+                Console.WriteLine("No Visual Studio instances found.");
+            }
+
+            Console.WriteLine("Visual Studio intances:");
+
+            foreach (var instance in instances)
+            {
+                Console.WriteLine($"  - {instance.Name} - {instance.Version}");
+                Console.WriteLine($"    {instance.MSBuildPath}");
+                Console.WriteLine();
+            }
+
+            var registeredInstance = instances.First();
+            MSBuildLocator.RegisterInstance(registeredInstance);
+
+            Console.WriteLine($"Registered: {registeredInstance.Name} - {registeredInstance.Version}");
+            Console.WriteLine();
+
             var workspace = MSBuildWorkspace.Create();
             var solution = workspace.OpenSolutionAsync(@"..\..\..\..\ClassLibrary1\ClassLibrary1.sln").Result;
 

--- a/Builder/Builder/packages.config
+++ b/Builder/Builder/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Build.Locator" version="1.0.13" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="2.6.0" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.Common" version="2.7.0" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.CSharp" version="2.7.0" targetFramework="net461" />


### PR DESCRIPTION
This PR shows how to make MSBuildWorkspace work with today's MSBuild:

1. The `Microsoft.Build.*` assemblies need to be deleted from your output folder.

    These are actually the real problem. Today, the package that includes MSBuildWorkspace pulls the MSBuild dlls into your application. However, those are almost certainly different than the ones required by the MSBuild toolset included in Visual Studio.

2. Use the `Microsoft.Build.Locator` package to find and register an instance of Visual Studio 2017.

    Now that your application doesn't include the `Microsoft.Build*`, it needs to find them somewhere. The `Microsoft.Build.Locator` package handles that for you. Once an instance of Visual Studio 2017 is registered, the locator adds an `AppDomain.AssemblyResolve` hook to load the `Microsoft.Build.*` from that instance of Visual Studio 2017. That way, the assemblies will match what's expected by the MSBuild toolset.

That's pretty much it!